### PR TITLE
Always cast the viewVal to string value

### DIFF
--- a/src/fcsaNumber.js
+++ b/src/fcsaNumber.js
@@ -115,7 +115,7 @@
           isValid = makeIsValid(options);
           ngModelCtrl.$parsers.unshift(function(viewVal) {
             var noCommasVal;
-            noCommasVal = viewVal.replace(/,/g, '');
+            noCommasVal = viewVal.toString().replace(/,/g, '');
             if (isValid(noCommasVal) || !noCommasVal) {
               ngModelCtrl.$setValidity('fcsaNumber', true);
               return noCommasVal;


### PR DESCRIPTION
On the occasional time it comes through as an integer, and then the .replace method fails. Casting the viewVal to string, ensures that this does not happen.
